### PR TITLE
fix: prevent intermittent test failure on context check

### DIFF
--- a/pkg/domain/context_test.go
+++ b/pkg/domain/context_test.go
@@ -32,13 +32,15 @@ func TestConnectWorkspace_Validate_AllDataSupplied(t *testing.T) {
 
 func TestConnectWorkspace_Run(t *testing.T) {
 	d := NewContext()
-
 	c := testKubeConfig()
+	// define contextKey upfront as iteration order of
+	// a map is non-deterministic
+	contextKey := getContextKey(c.Contexts, 0)
 	d.Config = &c
-	d.Context = getContextKey(c.Contexts, 0)
+	d.Context = contextKey
 
 	x := &c
-	x.CurrentContext = getContextKey(c.Contexts, 0)
+	x.CurrentContext = contextKey
 
 	var kuber = &kubefakes.FakeKuber{}
 	d.SetKuber(kuber)


### PR DESCRIPTION
The function `getContextKey` iterates over a map, of which the ordering of such is non-deterministic. As a result, using an index to select an entry within a map can result in different values per execution.