### PR TITLE
feat: trim control characters from graphql query before sending to GH

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -142,6 +142,12 @@ func (gr GraphQLErrorResponse) Error() string {
 func (c *Client) GraphQL(host string, query string, variables map[string]interface{}, data interface{}) error {
 	url := GetGraphQLAPIForHost(host)
 	log.Logger().Debugf("client.GraphQL: %s", url)
+
+	// prettify query before it is logged - makes it much easier to debug
+	query = strings.ReplaceAll(query, "\n", "")
+	query = strings.ReplaceAll(query, "\t", " ")
+	query = strings.ReplaceAll(query, "    ", " ")
+
 	reqBody, err := json.Marshal(map[string]interface{}{"query": query, "variables": variables})
 	if err != nil {
 		return err

--- a/pkg/cmd/getcmd/get_prs.go
+++ b/pkg/cmd/getcmd/get_prs.go
@@ -141,7 +141,7 @@ func (c *GetPrsCmd) Run() error {
 	if len(d.PullRequests) > 0 {
 		fmt.Printf("\nDisplaying %d PRs\n", len(d.PullRequests))
 	}
-	
+
 	if (d.FilteredBotAccounts + d.FilteredLabels) > 0 {
 		flags := []string{}
 		if d.FilteredBotAccounts > 0 {

--- a/pkg/cmd/getcmd/get_prs.go
+++ b/pkg/cmd/getcmd/get_prs.go
@@ -138,6 +138,10 @@ func (c *GetPrsCmd) Run() error {
 
 	table.Render()
 
+	if len(d.PullRequests) > 0 {
+		fmt.Printf("\nDisplaying %d PRs\n", len(d.PullRequests))
+	}
+	
 	if (d.FilteredBotAccounts + d.FilteredLabels) > 0 {
 		flags := []string{}
 		if d.FilteredBotAccounts > 0 {


### PR DESCRIPTION
When tracing the GH api, its quite hard to debug the query - you can't just copy and paste into the graphql explorer, this PR allows you to do that.