### PR TITLE
fix: rebase uses determined gh host

### DIFF
--- a/pkg/domain/gh_test.go
+++ b/pkg/domain/gh_test.go
@@ -71,14 +71,22 @@ func TestGetCurrentUser(t *testing.T) {
 	assert.Equal(t, currentUser, "octocat")
 }
 
-func TestGetOrgAndRepo(t *testing.T) {
-	org, repo, err := domain.ExtractOrgAndRepoURL("https://github.com/clone/chilly")
+func TestGetHostOrgAndRepo(t *testing.T) {
+	host, org, repo, err := domain.ExtractHostOrgAndRepoURL("https://github.com/clone/chilly")
 	assert.NoError(t, err)
+	assert.Equal(t, host, "github.com")
 	assert.Equal(t, org, "clone")
 	assert.Equal(t, repo, "chilly")
 
-	org, repo, err = domain.ExtractOrgAndRepoURL("https://github.com/plumming/dx")
+	host, org, repo, err = domain.ExtractHostOrgAndRepoURL("https://github.com/plumming/dx")
 	assert.NoError(t, err)
+	assert.Equal(t, host, "github.com")
+	assert.Equal(t, org, "plumming")
+	assert.Equal(t, repo, "dx")
+
+	host, org, repo, err = domain.ExtractHostOrgAndRepoURL("https://other.github.instance/plumming/dx")
+	assert.NoError(t, err)
+	assert.Equal(t, host, "other.github.instance")
 	assert.Equal(t, org, "plumming")
 	assert.Equal(t, repo, "dx")
 }

--- a/pkg/domain/git.go
+++ b/pkg/domain/git.go
@@ -194,18 +194,18 @@ func ExtractURLFromRemote(reader io.Reader, name string) (string, error) {
 	return "", nil
 }
 
-func ExtractOrgAndRepoURL(urlString string) (string, string, error) {
+func ExtractHostOrgAndRepoURL(urlString string) (string, string, string, error) {
 	urlString = strings.TrimSuffix(urlString, ".git")
 	url, err := url2.Parse(urlString)
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 
 	fragments := strings.Split(url.Path, "/")
 	if len(fragments) != 3 {
-		return "", "", errors.New("invalid url path '" + url.Path + "'")
+		return "", "", "", errors.New("invalid url path '" + url.Path + "'")
 	}
-	return fragments[1], fragments[2], nil
+	return url.Host, fragments[1], fragments[2], nil
 }
 
 func filter(in []string, test func(in string) bool) (out []string) {

--- a/pkg/domain/rebase.go
+++ b/pkg/domain/rebase.go
@@ -12,8 +12,10 @@ import (
 
 type Rebase struct {
 	cmd.CommonOptions
+	OriginHost            string
 	OriginOrg             string
 	OriginRepo            string
+	UpstreamHost          string
 	UpstreamOrg           string
 	UpstreamRepo          string
 	OriginDefaultBranch   string
@@ -52,25 +54,25 @@ func (c *Rebase) Validate() error {
 		return errors.New("origin & upstream appear to be the same: " + origin)
 	}
 
-	c.OriginOrg, c.OriginRepo, err = ExtractOrgAndRepoURL(origin)
+	c.OriginHost, c.OriginOrg, c.OriginRepo, err = ExtractHostOrgAndRepoURL(origin)
 	if err != nil {
 		return err
 	}
 	log.Logger().Debugf("determined origin repo as %s/%s", c.OriginOrg, c.OriginRepo)
 
-	c.OriginDefaultBranch, err = GetDefaultBranch(gh, "github.com", c.OriginOrg, c.OriginRepo)
+	c.OriginDefaultBranch, err = GetDefaultBranch(gh, c.OriginHost, c.OriginOrg, c.OriginRepo)
 	if err != nil {
 		return err
 	}
 	log.Logger().Debugf("determined origin default branch as %s", c.OriginDefaultBranch)
 
 	if upstream != "" {
-		c.UpstreamOrg, c.UpstreamRepo, err = ExtractOrgAndRepoURL(upstream)
+		c.UpstreamHost, c.UpstreamOrg, c.UpstreamRepo, err = ExtractHostOrgAndRepoURL(upstream)
 		if err != nil {
 			return err
 		}
 		log.Logger().Debugf("determined upstream repo as %s/%s", c.UpstreamOrg, c.UpstreamRepo)
-		c.UpstreamDefaultBranch, err = GetDefaultBranch(gh, "github.com", c.UpstreamOrg, c.UpstreamRepo)
+		c.UpstreamDefaultBranch, err = GetDefaultBranch(gh, c.UpstreamHost, c.UpstreamOrg, c.UpstreamRepo)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Use the result of `git remote -v` to determine the remote git repos, then extract the host so we can use the correct auth for each.  Should allow `dx rebase` to work against github enterprise