### PR TITLE
use proper tmp file

### DIFF
--- a/pkg/cmd/editcmd/edit_config.go
+++ b/pkg/cmd/editcmd/edit_config.go
@@ -3,7 +3,6 @@ package editcmd
 import (
 	"os"
 	"os/exec"
-	"path"
 
 	"github.com/jenkins-x/jx-logging/pkg/log"
 	"github.com/plumming/dx/pkg/config"
@@ -47,12 +46,11 @@ func (c *EditConfigCmd) Run() error {
 		editor = "vi"
 	}
 
-	fpath := path.Join(os.TempDir(), "thetemporaryfile.txt")
-	log.Logger().Infof("Tmp File %s", fpath)
-	f, err := os.Create(fpath)
+	f, err := os.CreateTemp("", "dx-*.yaml")
 	if err != nil {
 		log.Logger().Fatal(err)
 	}
+	log.Logger().Infof("Tmp File %s", f.Name())
 	err = f.Close()
 	if err != nil {
 		log.Logger().Fatal(err)
@@ -63,12 +61,12 @@ func (c *EditConfigCmd) Run() error {
 		log.Logger().Fatal(err)
 	}
 
-	err = configuration.SaveToFile(fpath)
+	err = configuration.SaveToFile(f.Name())
 	if err != nil {
 		log.Logger().Fatal(err)
 	}
 
-	cmd := exec.Command(editor, fpath)
+	cmd := exec.Command(editor, f.Name())
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -84,7 +82,7 @@ func (c *EditConfigCmd) Run() error {
 		log.Logger().Printf("Successfully edited.")
 	}
 
-	configuration, err = config.LoadFromFile(fpath)
+	configuration, err = config.LoadFromFile(f.Name())
 	if err != nil {
 		log.Logger().Fatal(err)
 	}


### PR DESCRIPTION
Disclaimer: I did not find any contribution guidelines, let me know if I missed something.

This PR basically fixes two things:
- the name of the tmp file when running `dx edit config` was hard-coded to `thetemporaryfile.txt`. This is a very generic name and might cause conflicts with other tools. Using golang built-in `os.CreateTemp` instead will make sure the names are unique. E.g. on Linux it generated this filename: `/tmp/dx-3458056123.yaml`
- The file extension was `.txt`, I changed it to `.yaml`, this is helpful, if your editor has some support for yaml editing (e.g. syntax highlighting) and detects this based on extensions.