### PR TITLE
create ".dx" folder if needed

### DIFF
--- a/pkg/config/file.go
+++ b/pkg/config/file.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"sort"
 
 	"gopkg.in/yaml.v2"
@@ -139,6 +140,10 @@ func (c *fileBasedConfig) GetMaxNumberOfPRs() int {
 }
 
 func (c *fileBasedConfig) SaveToDefaultLocation() error {
+	err := os.MkdirAll(util.ConfigDir(), 0700)
+	if err != nil {
+		return err
+	}
 	return c.SaveToFile(util.DxConfigFile())
 }
 


### PR DESCRIPTION
When running `dx edit config` for the first time, it will present you with some example config, which is quite nice.

Unfortunately `dx` crashes once you save the config with the following error:

`FATAL: open [...]/.dx/config.yml: no such file or directory`

Because the `.dx` directory does not exist (at least for 99% of first time users this will be the case). This gives a bad first impression.


This PR adds a call to `os.MkdirAll` for the `ConfigDir`, which will be a no-op if the directory already exists, but create the directory if needed. The directory will be only accessible to the current user (mode 700), which is in line with the mode 600 used for the actual config file.
