### PR TITLE
chore: capture branch protection rules

### DIFF
--- a/pkg/cmd/common_cmd_test.go
+++ b/pkg/cmd/common_cmd_test.go
@@ -23,6 +23,11 @@ func TestCommonCmd_Filter_AllData(t *testing.T) {
     "author": {
       "login": "author1"
     },
+    "baseRef": {
+      "branchProtectionRule": {
+        "requiredStatusCheckContexts": null
+      }
+    },
     "closed": false,
     "comments": {
       "totalCount": 0
@@ -47,6 +52,11 @@ func TestCommonCmd_Filter_AllData(t *testing.T) {
     "author": {
       "login": "author2"
     },
+    "baseRef": {
+      "branchProtectionRule": {
+        "requiredStatusCheckContexts": null
+      }
+    },
     "closed": false,
     "comments": {
       "totalCount": 0
@@ -70,6 +80,11 @@ func TestCommonCmd_Filter_AllData(t *testing.T) {
   {
     "author": {
       "login": "author3"
+    },
+    "baseRef": {
+      "branchProtectionRule": {
+        "requiredStatusCheckContexts": null
+      }
     },
     "closed": false,
     "comments": {
@@ -109,6 +124,11 @@ func TestCommonCmd_Filter_FilterOnAuthor(t *testing.T) {
   {
     "author": {
       "login": "author1"
+    },
+    "baseRef": {
+      "branchProtectionRule": {
+        "requiredStatusCheckContexts": null
+      }
     },
     "closed": false,
     "comments": {

--- a/pkg/domain/get_prs.go
+++ b/pkg/domain/get_prs.go
@@ -64,6 +64,11 @@ var (
             }
           }
         }
+        baseRef {
+          branchProtectionRule {
+            requiredStatusCheckContexts
+          }
+        }
       }
     }
   }

--- a/pkg/pr/pr.go
+++ b/pkg/pr/pr.go
@@ -22,6 +22,15 @@ type PullRequest struct {
 	Repository     Repository `json:"repository"`
 	Comments       Comments   `json:"comments"`
 	ReviewDecision string     `json:"reviewDecision"`
+	BaseRef        BaseRef    `json:"baseRef"`
+}
+
+type BaseRef struct {
+	BranchProtectionRule BranchProtectionRule `json:"branchProtectionRule"`
+}
+
+type BranchProtectionRule struct {
+	RequiredStatusCheckContexts []string `json:"requiredStatusCheckContexts"`
 }
 
 const (


### PR DESCRIPTION
These are not in use yet, but we want to capture them so we can build up a suite of test cases around the display of each commit status.