### PR TITLE
feat: allow a kubernetes config to be imported

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,3 +124,5 @@ docs: clean build
 lint:
 	golangci-lint run
 
+lint-fix:
+	golangci-lint run --fix

--- a/cmd/dx/dx.go
+++ b/cmd/dx/dx.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
-	"github.com/plumming/dx/pkg/cmd/importcmd"
 	"os"
 	"path"
 	"path/filepath"
 	"regexp"
 	"runtime/debug"
 	"strings"
+
+	"github.com/plumming/dx/pkg/cmd/importcmd"
 
 	"github.com/plumming/dx/pkg/brew"
 

--- a/cmd/dx/dx.go
+++ b/cmd/dx/dx.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/plumming/dx/pkg/cmd/importcmd"
 	"os"
 	"path"
 	"path/filepath"
@@ -78,6 +79,7 @@ func init() {
 	RootCmd.AddCommand(deletecmd.NewDeleteCmd())
 	RootCmd.AddCommand(editcmd.NewEditCmd())
 	RootCmd.AddCommand(getcmd.NewGetCmd())
+	RootCmd.AddCommand(importcmd.NewImportCmd())
 	RootCmd.AddCommand(upgradecmd.NewUpgradeCmd())
 	RootCmd.AddCommand(rebasecmd.NewRebaseCmd())
 	RootCmd.AddCommand(namespacecmd.NewNamespaceCmd())

--- a/pkg/cmd/importcmd/import.go
+++ b/pkg/cmd/importcmd/import.go
@@ -1,0 +1,40 @@
+package importcmd
+
+import (
+	"github.com/jenkins-x/jx-logging/pkg/log"
+	"github.com/spf13/cobra"
+)
+
+// ImportCmd defines parent import.
+type ImportCmd struct {
+	Cmd  *cobra.Command
+	Args []string
+}
+
+// NewImportCmd creates import cmd.
+func NewImportCmd() *cobra.Command {
+	c := &ImportCmd{}
+	cmd := &cobra.Command{
+		Use:     "import",
+		Short:   "",
+		Long:    "",
+		Example: "",
+		Run: func(cmd *cobra.Command, args []string) {
+			c.Cmd = cmd
+			c.Args = args
+			err := c.Run()
+			if err != nil {
+				log.Logger().WithError(err).Fatal("unable to run command")
+			}
+		},
+	}
+
+	cmd.AddCommand(NewImportContextCmd())
+
+	return cmd
+}
+
+// Run import help.
+func (c *ImportCmd) Run() error {
+	return c.Cmd.Help()
+}

--- a/pkg/cmd/importcmd/import_context.go
+++ b/pkg/cmd/importcmd/import_context.go
@@ -36,7 +36,10 @@ func NewImportContextCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&c.Path, "path", "f", "",
 		"Path to the context file to import")
-	cmd.MarkFlagRequired("path")
+	err := cmd.MarkFlagRequired("path")
+	if err != nil {
+		panic(err)
+	}
 
 	return cmd
 }

--- a/pkg/cmd/importcmd/import_context.go
+++ b/pkg/cmd/importcmd/import_context.go
@@ -1,0 +1,58 @@
+package importcmd
+
+import (
+	"github.com/jenkins-x/jx-logging/pkg/log"
+	"github.com/pkg/errors"
+	"github.com/plumming/dx/pkg/cmd"
+	"github.com/plumming/dx/pkg/domain"
+	"github.com/spf13/cobra"
+)
+
+type ImportContextCmd struct {
+	cmd.CommonCmd
+	Path string
+	Cmd  *cobra.Command
+	Args []string
+}
+
+func NewImportContextCmd() *cobra.Command {
+	c := &ImportContextCmd{}
+	cmd := &cobra.Command{
+		Use:     "context",
+		Short:   "Import a kubernetes context",
+		Long:    "",
+		Example: "",
+		Aliases: []string{"ctx", "c"},
+		Run: func(cmd *cobra.Command, args []string) {
+			c.Cmd = cmd
+			c.Args = args
+			err := c.Run()
+			if err != nil {
+				log.Logger().Fatalf("unable to run command: %s", err)
+			}
+		},
+		Args: cobra.NoArgs,
+	}
+
+	cmd.Flags().StringVarP(&c.Path, "path", "f", "",
+		"Path to the context file to import")
+	cmd.MarkFlagRequired("path")
+
+	return cmd
+}
+
+func (c *ImportContextCmd) Run() error {
+	d := domain.NewImportContext(c.Path)
+
+	err := d.Validate()
+	if err != nil {
+		return errors.Wrap(err, "validate failed")
+	}
+
+	err = d.Run()
+	if err != nil {
+		return errors.Wrap(err, "run failed")
+	}
+
+	return nil
+}

--- a/pkg/domain/import_context.go
+++ b/pkg/domain/import_context.go
@@ -1,0 +1,78 @@
+package domain
+
+import (
+	"github.com/jenkins-x/jx-logging/pkg/log"
+	"github.com/plumming/dx/pkg/cmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+// ImportContext defines Kubernetes context.
+type ImportContext struct {
+	cmd.CommonOptions
+	Path           string
+	Config         *api.Config
+	ConfigToImport *api.Config
+}
+
+// NewImportContext creates a new ImportContext.
+func NewImportContext(path string) *ImportContext {
+	c := &ImportContext{
+		Path: path,
+	}
+	return c
+}
+
+// Validate input.
+func (c *ImportContext) Validate() error {
+	k := c.Kuber()
+	var err error
+
+	c.Config, err = k.LoadAPIConfig()
+	if err != nil {
+		return err
+	}
+
+	// load api config from path
+	c.ConfigToImport, err = k.LoadAPIConfigFromPath(c.Path)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Run the cmd.
+func (c *ImportContext) Run() error {
+	log.Logger().Infof("Importing from %s", c.Path)
+
+	kuber := c.Kuber()
+
+	newConfig := c.Config
+
+	for k, v := range c.ConfigToImport.Contexts {
+		log.Logger().Debugf("context %s", k)
+		newConfig.Contexts[k] = v
+	}
+
+	for k, v := range c.ConfigToImport.AuthInfos {
+		log.Logger().Debugf("authInfo %s", k)
+		newConfig.AuthInfos[k] = v
+	}
+
+	for k, v := range c.ConfigToImport.Clusters {
+		log.Logger().Debugf("cluster %s", k)
+		newConfig.Clusters[k] = v
+	}
+
+	for k, v := range c.ConfigToImport.Extensions {
+		log.Logger().Debugf("extensions %s", k)
+		newConfig.Extensions[k] = v
+	}
+
+	_, err := kuber.SetKubeConfig(newConfig)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/kube/factory.go
+++ b/pkg/kube/factory.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/jenkins-x/jx-logging/pkg/log"
+
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -49,6 +51,7 @@ func (f *factory) SetKubeNamespace(namespace string, config *api.Config) (*api.C
 
 func (f *factory) SetKubeConfig(config *api.Config) (*api.Config, error) {
 	newConfig := *config
+	log.Logger().Debugf("persisting %+v", newConfig)
 	err := clientcmd.ModifyConfig(clientcmd.NewDefaultPathOptions(), newConfig, false)
 	if err != nil {
 		return nil, err
@@ -78,7 +81,6 @@ func (f *factory) LoadAPIConfigFromPath(path string) (*api.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	return apiConfig, nil
 }
 

--- a/pkg/kube/factory.go
+++ b/pkg/kube/factory.go
@@ -47,6 +47,15 @@ func (f *factory) SetKubeNamespace(namespace string, config *api.Config) (*api.C
 	return &newConfig, nil
 }
 
+func (f *factory) SetKubeConfig(config *api.Config) (*api.Config, error) {
+	newConfig := *config
+	err := clientcmd.ModifyConfig(clientcmd.NewDefaultPathOptions(), newConfig, false)
+	if err != nil {
+		return nil, err
+	}
+	return &newConfig, nil
+}
+
 func NewKuber() Kuber {
 	return &factory{}
 }
@@ -57,6 +66,15 @@ func (f *factory) LoadAPIConfig() (*api.Config, error) {
 		return nil, errors.New("unable to get kube config path options")
 	}
 	apiConfig, err := po.GetStartingConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return apiConfig, nil
+}
+
+func (f *factory) LoadAPIConfigFromPath(path string) (*api.Config, error) {
+	apiConfig, err := clientcmd.LoadFromFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kube/interface.go
+++ b/pkg/kube/interface.go
@@ -10,7 +10,9 @@ import (
 type Kuber interface {
 	SetKubeContext(string, *api.Config) (*api.Config, error)
 	SetKubeNamespace(string, *api.Config) (*api.Config, error)
+	SetKubeConfig(*api.Config) (*api.Config, error)
 	LoadAPIConfig() (*api.Config, error)
+	LoadAPIConfigFromPath(string) (*api.Config, error)
 	LoadClientConfig() (*rest.Config, error)
 	GetCurrentContext(*api.Config) *api.Context
 	GetCurrentNamespace(*api.Config) string

--- a/pkg/kube/kubefakes/fake_kuber.go
+++ b/pkg/kube/kubefakes/fake_kuber.go
@@ -44,6 +44,19 @@ type FakeKuber struct {
 		result1 *api.Config
 		result2 error
 	}
+	LoadAPIConfigFromPathStub        func(string) (*api.Config, error)
+	loadAPIConfigFromPathMutex       sync.RWMutex
+	loadAPIConfigFromPathArgsForCall []struct {
+		arg1 string
+	}
+	loadAPIConfigFromPathReturns struct {
+		result1 *api.Config
+		result2 error
+	}
+	loadAPIConfigFromPathReturnsOnCall map[int]struct {
+		result1 *api.Config
+		result2 error
+	}
 	LoadClientConfigStub        func() (*rest.Config, error)
 	loadClientConfigMutex       sync.RWMutex
 	loadClientConfigArgsForCall []struct {
@@ -54,6 +67,19 @@ type FakeKuber struct {
 	}
 	loadClientConfigReturnsOnCall map[int]struct {
 		result1 *rest.Config
+		result2 error
+	}
+	SetKubeConfigStub        func(*api.Config) (*api.Config, error)
+	setKubeConfigMutex       sync.RWMutex
+	setKubeConfigArgsForCall []struct {
+		arg1 *api.Config
+	}
+	setKubeConfigReturns struct {
+		result1 *api.Config
+		result2 error
+	}
+	setKubeConfigReturnsOnCall map[int]struct {
+		result1 *api.Config
 		result2 error
 	}
 	SetKubeContextStub        func(string, *api.Config) (*api.Config, error)
@@ -266,6 +292,70 @@ func (fake *FakeKuber) LoadAPIConfigReturnsOnCall(i int, result1 *api.Config, re
 	}{result1, result2}
 }
 
+func (fake *FakeKuber) LoadAPIConfigFromPath(arg1 string) (*api.Config, error) {
+	fake.loadAPIConfigFromPathMutex.Lock()
+	ret, specificReturn := fake.loadAPIConfigFromPathReturnsOnCall[len(fake.loadAPIConfigFromPathArgsForCall)]
+	fake.loadAPIConfigFromPathArgsForCall = append(fake.loadAPIConfigFromPathArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.LoadAPIConfigFromPathStub
+	fakeReturns := fake.loadAPIConfigFromPathReturns
+	fake.recordInvocation("LoadAPIConfigFromPath", []interface{}{arg1})
+	fake.loadAPIConfigFromPathMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeKuber) LoadAPIConfigFromPathCallCount() int {
+	fake.loadAPIConfigFromPathMutex.RLock()
+	defer fake.loadAPIConfigFromPathMutex.RUnlock()
+	return len(fake.loadAPIConfigFromPathArgsForCall)
+}
+
+func (fake *FakeKuber) LoadAPIConfigFromPathCalls(stub func(string) (*api.Config, error)) {
+	fake.loadAPIConfigFromPathMutex.Lock()
+	defer fake.loadAPIConfigFromPathMutex.Unlock()
+	fake.LoadAPIConfigFromPathStub = stub
+}
+
+func (fake *FakeKuber) LoadAPIConfigFromPathArgsForCall(i int) string {
+	fake.loadAPIConfigFromPathMutex.RLock()
+	defer fake.loadAPIConfigFromPathMutex.RUnlock()
+	argsForCall := fake.loadAPIConfigFromPathArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeKuber) LoadAPIConfigFromPathReturns(result1 *api.Config, result2 error) {
+	fake.loadAPIConfigFromPathMutex.Lock()
+	defer fake.loadAPIConfigFromPathMutex.Unlock()
+	fake.LoadAPIConfigFromPathStub = nil
+	fake.loadAPIConfigFromPathReturns = struct {
+		result1 *api.Config
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeKuber) LoadAPIConfigFromPathReturnsOnCall(i int, result1 *api.Config, result2 error) {
+	fake.loadAPIConfigFromPathMutex.Lock()
+	defer fake.loadAPIConfigFromPathMutex.Unlock()
+	fake.LoadAPIConfigFromPathStub = nil
+	if fake.loadAPIConfigFromPathReturnsOnCall == nil {
+		fake.loadAPIConfigFromPathReturnsOnCall = make(map[int]struct {
+			result1 *api.Config
+			result2 error
+		})
+	}
+	fake.loadAPIConfigFromPathReturnsOnCall[i] = struct {
+		result1 *api.Config
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeKuber) LoadClientConfig() (*rest.Config, error) {
 	fake.loadClientConfigMutex.Lock()
 	ret, specificReturn := fake.loadClientConfigReturnsOnCall[len(fake.loadClientConfigArgsForCall)]
@@ -318,6 +408,70 @@ func (fake *FakeKuber) LoadClientConfigReturnsOnCall(i int, result1 *rest.Config
 	}
 	fake.loadClientConfigReturnsOnCall[i] = struct {
 		result1 *rest.Config
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeKuber) SetKubeConfig(arg1 *api.Config) (*api.Config, error) {
+	fake.setKubeConfigMutex.Lock()
+	ret, specificReturn := fake.setKubeConfigReturnsOnCall[len(fake.setKubeConfigArgsForCall)]
+	fake.setKubeConfigArgsForCall = append(fake.setKubeConfigArgsForCall, struct {
+		arg1 *api.Config
+	}{arg1})
+	stub := fake.SetKubeConfigStub
+	fakeReturns := fake.setKubeConfigReturns
+	fake.recordInvocation("SetKubeConfig", []interface{}{arg1})
+	fake.setKubeConfigMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeKuber) SetKubeConfigCallCount() int {
+	fake.setKubeConfigMutex.RLock()
+	defer fake.setKubeConfigMutex.RUnlock()
+	return len(fake.setKubeConfigArgsForCall)
+}
+
+func (fake *FakeKuber) SetKubeConfigCalls(stub func(*api.Config) (*api.Config, error)) {
+	fake.setKubeConfigMutex.Lock()
+	defer fake.setKubeConfigMutex.Unlock()
+	fake.SetKubeConfigStub = stub
+}
+
+func (fake *FakeKuber) SetKubeConfigArgsForCall(i int) *api.Config {
+	fake.setKubeConfigMutex.RLock()
+	defer fake.setKubeConfigMutex.RUnlock()
+	argsForCall := fake.setKubeConfigArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeKuber) SetKubeConfigReturns(result1 *api.Config, result2 error) {
+	fake.setKubeConfigMutex.Lock()
+	defer fake.setKubeConfigMutex.Unlock()
+	fake.SetKubeConfigStub = nil
+	fake.setKubeConfigReturns = struct {
+		result1 *api.Config
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeKuber) SetKubeConfigReturnsOnCall(i int, result1 *api.Config, result2 error) {
+	fake.setKubeConfigMutex.Lock()
+	defer fake.setKubeConfigMutex.Unlock()
+	fake.SetKubeConfigStub = nil
+	if fake.setKubeConfigReturnsOnCall == nil {
+		fake.setKubeConfigReturnsOnCall = make(map[int]struct {
+			result1 *api.Config
+			result2 error
+		})
+	}
+	fake.setKubeConfigReturnsOnCall[i] = struct {
+		result1 *api.Config
 		result2 error
 	}{result1, result2}
 }
@@ -461,8 +615,12 @@ func (fake *FakeKuber) Invocations() map[string][][]interface{} {
 	defer fake.getCurrentNamespaceMutex.RUnlock()
 	fake.loadAPIConfigMutex.RLock()
 	defer fake.loadAPIConfigMutex.RUnlock()
+	fake.loadAPIConfigFromPathMutex.RLock()
+	defer fake.loadAPIConfigFromPathMutex.RUnlock()
 	fake.loadClientConfigMutex.RLock()
 	defer fake.loadClientConfigMutex.RUnlock()
+	fake.setKubeConfigMutex.RLock()
+	defer fake.setKubeConfigMutex.RUnlock()
 	fake.setKubeContextMutex.RLock()
 	defer fake.setKubeContextMutex.RUnlock()
 	fake.setKubeNamespaceMutex.RLock()


### PR DESCRIPTION
```
dx import context -f ll
```

can be used to import config from the supplied config file to the "default location".

Where "default location" is the path used to store the current context, usually `~/.kube/config`